### PR TITLE
Fix "PHP Notice: Undefined variable: GLOBALS"

### DIFF
--- a/OLE/ChainedBlockStream.php
+++ b/OLE/ChainedBlockStream.php
@@ -144,7 +144,9 @@ class OLE_ChainedBlockStream extends PEAR
     function stream_close()
     {
         $this->ole = null;
-        unset($GLOBALS['_OLE_INSTANCES']);
+        if (isset($GLOBALS)) {
+            unset($GLOBALS['_OLE_INSTANCES']);
+        }
     }
 
     /**


### PR DESCRIPTION
I'm getting this notice, so it looks like [the presumption the variable exists](https://github.com/hfig/OLE/blob/ec2a4ad2f7b64f8079a0563c4ddfaa8935a464ee/OLE/ChainedBlockStream.php#L147) is wrong...

I would resend this PR into official stream too, but it looks abandoned. And I'm using your hfig/MAPI, so I'd like to have it fixed...

**update:**
I'm confused by this notice found in log. **`$GLOBALS`** should always exist, while it is one of the PHP predefined variables. I'm getting this error only in tests. If I try to test existence of the variable with `isset($GLOBALS)`, it exists.

It's kind of strange.